### PR TITLE
Support for multiple output transformations

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -96,9 +96,11 @@ export default function plugin(pluginOpts: PluginOptions = {}): Plugin {
             options,
           ])
           if (transformResult == null) {
+            /*
             console.warn(
               `Parent plugin ${parentPlugin.name} refused to transform output of vite-plugin-civet`,
             )
+            */
           }
           else if (typeof transformResult === 'string') {
             transformed.code = transformResult


### PR DESCRIPTION
This PR adds support for multiple "parent" plugins that run after the Civet transform. I found myself wanting this to transform JSX and to add extra features like [compile-time constants](https://github.com/egoist/vite-plugin-compile-time).

The new interface is that `outputTransformerPlugin` can be a single string or an array of strings. Is this a normal singular/plural interface? Happy to change if there's something else more standard.

I also removed the warning about a parent plugin not doing anything.  [vite-plugin-compile-time](https://github.com/egoist/vite-plugin-compile-time) does this whenever a file doesn't have the directive it's looking for, so it isn't particularly noteworthy.