### PR TITLE
Run esbuild on .civet files after transform

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,19 @@ export default function plugin(pluginOpts: PluginOptions = {}): Plugin {
 
   return {
     name: 'vite:civet',
+    enforce: 'pre', // run esbuild after transform
+
+    config(config, { command }) {
+      // Ensure esbuild runs on .civet files
+      if (command === 'build') {
+        return {
+          esbuild: {
+            include: [/\.civet$/],
+            loader: 'tsx',
+          },
+        }
+      }
+    },
 
     configResolved(resolvedConfig) {
       if (!pluginOpts.outputTransformerPlugin)


### PR DESCRIPTION
Fixes #3. `playground-react-swc` now builds!

This took me a lot of investigation, but I think the new solution is correct.
* Turns out `config` options were already getting passed through; the issue is that the esbuild step wasn't running.
* Add to `esbuild.include` to ensure `.civet` files get passed through esbuild.
* Add `enforce: 'pre'` to ensure esbuild runs after transpilation. React and Solid already had this `enforce` so not surprising.